### PR TITLE
Fix browser redirect to onGuestOnly

### DIFF
--- a/src/runtime/middleware/sanctum.guest.ts
+++ b/src/runtime/middleware/sanctum.guest.ts
@@ -5,9 +5,10 @@ import {
     createError,
 } from '#app';
 import type { SanctumModuleOptions } from '../../types';
+import type { RouteLocationRaw } from 'vue-router';
 import { useSanctumUser } from '../composables/useSanctumUser';
 
-export default defineNuxtRouteMiddleware(() => {
+export default defineNuxtRouteMiddleware((to, from) => {
     const user = useSanctumUser();
     const options = useRuntimeConfig().public.sanctum as SanctumModuleOptions;
 
@@ -21,6 +22,13 @@ export default defineNuxtRouteMiddleware(() => {
 
     if (endpoint === false) {
         throw createError({ statusCode: 403 });
+    }
+
+    if (options.redirect.keepRequestedRoute) {
+        if (from.path === options.redirect.onAuthOnly) {
+            const actualPath = from.query.redirect as RouteLocationRaw;
+            return navigateTo(actualPath, { replace: true });
+        }
     }
 
     return navigateTo(endpoint, { replace: true });


### PR DESCRIPTION
Attempt to fix redirect on hard refresh and when directly visiting authenticated path.

### Previous behaviour
- Browser will redirect user to `onGuestOnly` path when user directly visiting the authenticated path or page is refresh

### New behaviour
- The browser will redirect user to authenticated path/page if user is authenticated.

### Expected behaviour
- When user directly visit the authenticated page, the page will redirect user to `/login` page first before redirect again to actual path